### PR TITLE
Nonce + Permissions check for ajax posts

### DIFF
--- a/hm-related-posts-admin.php
+++ b/hm-related-posts-admin.php
@@ -86,9 +86,11 @@ function hm_rp_override_metabox_script( $id, $value = false, $ajax_args = false 
 
 	$query = json_encode( $ajax_args ? wp_parse_args( $ajax_args ) : (object) array() );
 
-	$url = add_query_arg( 'action', 'hm_rp_ajax_post_select', admin_url( 'admin-ajax.php' ) );
-	$url = add_query_arg( 'hm_rp_ajax_post_select_nonce', wp_create_nonce( 'hm_rp_ajax_post_select' ), $url );
-	$url = add_query_arg( 'post_id', get_the_id(), $url );
+	$url = add_query_arg( array( 
+		'action' => 'hm_rp_ajax_post_select', 
+		'hm_rp_ajax_post_select_nonce' => wp_create_nonce( 'hm_rp_ajax_post_select' ),
+		'post_id' => get_the_id()
+	), admin_url( 'admin-ajax.php' ) );
 
 	?>
 


### PR DESCRIPTION
I have added both a nonce check and a permissions check.

Do I need to do more to sanitize the query? I would like to be able to specify any WP Query ans for that to be handled OK by the AJAX callback. Doesn't WP_Query sanitize any input?

@danielbachuber If I need to do more - could you advise?

Thanks
