### PR TITLE
Sanitize WP Query

### DIFF
--- a/hm-related-posts-admin.php
+++ b/hm-related-posts-admin.php
@@ -109,7 +109,6 @@ function hm_rp_override_metabox_script( $id, $value = false, $ajax_args = false 
 				data: function( term, page ) {
 					query.s = term;
 					query.paged = page;
-					query.wat = 'hello';
 					return {query:query};
 				},
 				results : function( data, page ) {


### PR DESCRIPTION
> It's safest just to sanitize everything.

@danielbachhuber  in #1 

I may have misunderstood - but did you mean we cannot rely on parse_query to sanitize the args we are passing to WP_Query

I have tried to sanitize all the possible args below... am I being crazy?

cc @danielbachhuber 
