### PR TITLE
Associated related posts don't override article posts

### DIFF
--- a/hm-related-posts.php
+++ b/hm-related-posts.php
@@ -95,6 +95,7 @@ function hm_rp_get_related_posts( $limit = 10, $post_types = array( 'post' ), $t
 
 		}
 
+		$related_posts = array_slice( $related_posts, 0, $limit );
 
 		set_transient( $post_id . $hash, $related_posts, 'hm_related_posts', HOUR_IN_SECONDS );
 


### PR DESCRIPTION
I specified three related posts like this:

![image](https://f.cloud.github.com/assets/36432/1162017/42263f80-2000-11e3-90be-b6baa637b197.png)

I expected them to override the related posts. Instead, they seem to be included in all of the posts:

![image](https://f.cloud.github.com/assets/36432/1162024/6af86fdc-2000-11e3-91e7-6998c0186a66.png)
