### PR TITLE
Fix hmrp

### DIFF
--- a/hm-related-posts.php
+++ b/hm-related-posts.php
@@ -34,7 +34,7 @@ function hm_rp_get_related_posts( $post_id, $args = array() ) {
 
 	extract( $args );
 
-	$transient = sprintf( 'hm_rp_%s_%s', $post_id, hash( 'md5', json_encode( $args ) ) );
+	$transient = sprintf( 'hmrp_%s_%s', $post_id, hash( 'md5', json_encode( $args ) ) );
 
 	if ( ! $related_posts = get_transient( $transient ) ) :
 


### PR DESCRIPTION
A bit of a bug - I was using the args for wp_cache_set for set_transient. Which of course are different! This means we pass a string as expiry, which is cast to 0 and means that transients had no expiry. 

However with this I am going to make a few backwards compatability breaking changes.
- Transient key is changed, prefixing it with _hmrp_$postID to make it easier to identify our transients in future.
- Args for `hm_rp_get_related_posts` are changed
  - 1st param - pass in post id.
  - 2nd param passed as a single array of args
  - all cache args are then used to generate hash for transient key.

I suggest we tag this as a version 1.0 release so we can better track future changes 
